### PR TITLE
Update Piraeus version to 2.10.7

### DIFF
--- a/charts/piraeus/metadata.yaml
+++ b/charts/piraeus/metadata.yaml
@@ -1,4 +1,4 @@
 ---
 registry: https://notHiks.github.io/charts/
 name: piraeus
-version: 2.10.5
+version: 2.10.7


### PR DESCRIPTION
Update the Piraeus version in the metadata to reflect the latest release.